### PR TITLE
add colorbar module

### DIFF
--- a/Physika_Src/Physika_Render/ColorBar/ColorMap/color_map.cpp
+++ b/Physika_Src/Physika_Render/ColorBar/ColorMap/color_map.cpp
@@ -1,0 +1,348 @@
+/*
+ * @file color_map.cpp
+ * @Brief a color map class for OpenGL.
+ * @author Wei Chen
+ * 
+ * This file is part of Physika, a versatile physics simulation library.
+ * Copyright (C) 2013 Physika Group.
+ *
+ * This Source Code Form is subject to the terms of the GNU General Public License v2.0. 
+ * If a copy of the GPL was not distributed with this file, you can obtain one at:
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+#include <cmath>
+#include "Physika_Core/Utilities/math_utilities.h"
+#include "Physika_Render/ColorBar/ColorMap/color_map.h"
+
+namespace Physika{
+
+template <typename Scalar>
+ColorMap<Scalar>::ColorMap()
+{
+    this->color_map_vec_.resize(64);
+    this->color_map_type_ = ColorMapType::Jet;
+    this->jetColorMap();
+}
+
+template <typename Scalar>
+ColorMap<Scalar>::ColorMap(ColorMapType color_map_type, unsigned int color_size)
+{
+    this->color_map_vec_.resize(color_size);
+    this->setColorMapType(color_map_type);
+}
+
+template <typename Scalar>
+ColorMap<Scalar>::~ColorMap()
+{
+
+}
+
+template <typename Scalar>
+ColorMapType ColorMap<Scalar>::colorMapType() const
+{
+    return this->color_map_type_;
+}
+
+template <typename Scalar>
+unsigned int ColorMap<Scalar>::colorMapSize() const
+{
+    return this->color_map_vec_.size();
+}
+
+template <typename Scalar>
+const std::vector<Color<Scalar> > & ColorMap<Scalar>::colorMapVec() const
+{
+    return this->color_map_vec_;
+}
+
+template <typename Scalar>
+const Color<Scalar> & ColorMap<Scalar>::colorViaRatio(Scalar ratio) const
+{
+    if (ratio < 0.0) ratio = 0.0;
+    if (ratio > 1.0) ratio = 1.0;
+    unsigned int index = ratio*this->color_map_vec_.size();
+    return this->colorViaIndex(index);
+}
+
+template <typename Scalar>
+const Color<Scalar> & ColorMap<Scalar>::colorViaIndex(unsigned int index)const
+{
+    if (index >= this->color_map_vec_.size()) index = this->color_map_vec_.size()-1;
+    return this->color_map_vec_[index];
+}
+
+template <typename Scalar>
+void ColorMap<Scalar>::setColorMapSize(unsigned int color_size)
+{
+    if (color_size < 1)
+    {
+        std::cerr<<"color map size should be greater than 1.\n";
+        std::exit(EXIT_FAILURE);
+    }
+    this->color_map_vec_.resize(color_size);
+    this->setColorMapType(this->color_map_type_);
+}
+
+template <typename Scalar>
+void ColorMap<Scalar>::setColorMapType(ColorMapType color_map_type)
+{
+    
+    for (unsigned int i=0; i< color_map_vec_.size(); i++)
+    {
+        color_map_vec_[i] = Color<Scalar>();
+    }
+    
+    this->color_map_type_ = color_map_type;
+    switch(color_map_type)
+    {
+        case ColorMapType::Gray:   {grayColorMap(); break;}
+        case ColorMapType::Red:    {redColorMap(); break;}
+        case ColorMapType::Green:  {greenColorMap(); break;}
+        case ColorMapType::Blue:   {blueColorMap(); break;}
+        case ColorMapType::Jet:    {jetColorMap(); break;}
+        case ColorMapType::Spring: {springColorMap(); break;}
+        case ColorMapType::Summer: {summerColorMap(); break;}
+        case ColorMapType::Autumn: {autumnColorMap(); break;}
+        case ColorMapType::Winter: {winterColorMap(); break;}
+        case ColorMapType::Hot:    {hotColorMap(); break;}
+        case ColorMapType::Cool:   {coolColorMap(); break;}
+    }
+}
+
+template <typename Scalar>
+void ColorMap<Scalar>::setColorMapTypeAndSize(ColorMapType color_map_type, unsigned int color_size)
+{
+    if (color_size < 1)
+    {
+        std::cerr<<"color map size should be greater than 1.\n";
+        std::exit(EXIT_FAILURE);
+    }
+    this->color_map_vec_.resize(color_size);
+    this->setColorMapType(color_map_type);
+}
+
+template <typename Scalar>
+void ColorMap<Scalar>::grayColorMap()
+{
+    unsigned int m = max<unsigned int>(color_map_vec_.size()-1,1);
+    for (unsigned int i=0; i<color_map_vec_.size(); i++)
+    {
+        Scalar g = static_cast<Scalar>(i)/m;
+        color_map_vec_[i].setRedChannel(g);
+        color_map_vec_[i].setGreenChannel(g);
+        color_map_vec_[i].setBlueChannel(g);
+    }
+}
+
+template <typename Scalar>
+void ColorMap<Scalar>::redColorMap()
+{
+    unsigned int m = max<unsigned int>(color_map_vec_.size()-1,1);
+    for (unsigned int i=0; i<color_map_vec_.size(); i++)
+    {
+        Scalar r = static_cast<Scalar>(i)/m;
+        color_map_vec_[i].setRedChannel(r);
+    }
+}
+
+template <typename Scalar>
+void ColorMap<Scalar>::greenColorMap()
+{
+    unsigned int m = max<unsigned int>(color_map_vec_.size()-1,1);
+    for (unsigned int i=0; i<color_map_vec_.size(); i++)
+    {
+        Scalar g = static_cast<Scalar>(i)/m;
+        color_map_vec_[i].setGreenChannel(g);
+    }
+}
+
+template <typename Scalar>
+void ColorMap<Scalar>::blueColorMap()
+{
+    unsigned int m = max<unsigned int>(color_map_vec_.size()-1,1);
+    for (unsigned int i=0; i<color_map_vec_.size(); i++)
+    {
+        Scalar b = static_cast<Scalar>(i)/m;
+        color_map_vec_[i].setBlueChannel(b);
+    }
+}
+
+template <typename Scalar>
+void ColorMap<Scalar>::jetColorMap()
+{
+    unsigned int m = color_map_vec_.size();
+    unsigned int n = std::ceil((float)m/4);
+    std::vector<Scalar> u;
+    for (unsigned int i=1; i<=n; i++)
+    {
+        u.push_back(static_cast<Scalar>(i)/n);
+    }
+    for (unsigned int i=1; i<=n-1; i++)
+    {
+        u.push_back(1.0);
+    }
+    for (unsigned int i=n; i>=1; i--)
+    {
+        u.push_back(static_cast<Scalar>(i)/n);
+    }
+    std::vector<unsigned int> g;
+    int temp = std::ceil((float)n/2) - (m%4==1);
+    for (unsigned int i=1; i<=u.size(); i++)
+    {
+        int temp_g = temp+i;
+        if(temp_g<=m) g.push_back(temp_g);
+    }
+    std::vector<unsigned int> r;
+    for (unsigned int i=0; i< g.size(); i++)
+    {
+        int temp_r = g[i]+n;
+        if(temp_r<=m) r.push_back(temp_r);
+    }
+    std::vector<unsigned int> b;
+    for (unsigned int i=0; i< g.size(); i++)
+    {
+        int temp_b = g[i]-n;
+        if(temp_b>=1) b.push_back(temp_b);
+    }
+
+    for (unsigned int i=0; i<r.size(); i++)
+    {
+        color_map_vec_[r[i]-1].setRedChannel(u[i]);
+    }
+    for (unsigned int i=0; i<g.size(); i++)
+    {
+        color_map_vec_[g[i]-1].setGreenChannel(u[i]);
+    }
+    temp = u.size() - b.size();
+    for (unsigned int i=0; i<b.size(); i++)
+    {
+        color_map_vec_[b[i]-1].setBlueChannel(u[temp+i]);
+    }
+}
+
+template <typename Scalar>
+void ColorMap<Scalar>::springColorMap()
+{
+    unsigned int m = max<unsigned int>(color_map_vec_.size()-1,1);
+    for (unsigned int i=0; i<color_map_vec_.size(); i++)
+    {
+        Scalar r = static_cast<Scalar>(i)/m;
+        color_map_vec_[i].setRedChannel(1.0);
+        color_map_vec_[i].setGreenChannel(r);
+        color_map_vec_[i].setBlueChannel(1.0-r);
+    }
+}
+
+template <typename Scalar>
+void ColorMap<Scalar>::summerColorMap()
+{
+    unsigned int m = color_map_vec_.size();
+    unsigned int n = max<unsigned int>(m-1,1);
+    std::vector<Scalar> r;
+    for (unsigned int i=0; i<= m-1; i++)
+    {
+        r.push_back(static_cast<Scalar>(i)/n);
+    }
+    for (unsigned int i=0; i<m; i++)
+    {
+        color_map_vec_[i].setRedChannel(r[i]);
+        color_map_vec_[i].setGreenChannel(0.5+r[i]/2);
+        color_map_vec_[i].setBlueChannel(0.4);
+    }
+}
+
+template <typename Scalar>
+void ColorMap<Scalar>::autumnColorMap()
+{
+    unsigned int m = color_map_vec_.size();
+    unsigned int n = max<unsigned int>(m-1,1);
+    std::vector<Scalar> r;
+    for (unsigned int i=0; i<= m-1; i++)
+    {
+        r.push_back(static_cast<Scalar>(i)/n);
+    }
+    for (unsigned int i=0; i<m; i++)
+    {
+        color_map_vec_[i].setRedChannel(1.0);
+        color_map_vec_[i].setGreenChannel(r[i]);
+        color_map_vec_[i].setBlueChannel(0.0);
+    }
+}
+
+template <typename Scalar>
+void ColorMap<Scalar>::winterColorMap()
+{
+    unsigned int m = color_map_vec_.size();
+    unsigned int n = max<unsigned int>(m-1,1);
+    std::vector<Scalar> r;
+    for (unsigned int i=0; i<= m-1; i++)
+    {
+        r.push_back(static_cast<Scalar>(i)/n);
+    }
+    for (unsigned int i=0; i<m; i++)
+    {
+        color_map_vec_[i].setRedChannel(0.0);
+        color_map_vec_[i].setGreenChannel(r[i]);
+        color_map_vec_[i].setBlueChannel(0.5+(1-r[i])/2);
+    }
+}
+
+template <typename Scalar>
+void ColorMap<Scalar>::hotColorMap()
+{
+    unsigned int m = color_map_vec_.size();
+    unsigned int n = floor(3.0/8.0*m);
+    std::vector<Scalar> r;
+    for (unsigned int i=1; i<=n ;i++)
+    {
+        r.push_back(static_cast<Scalar>(i)/n);
+    }
+    r.insert(r.end(), m-n, 1);
+
+    std::vector<Scalar> g;
+    g.insert(g.end(),n,0);
+    for (unsigned int i=1; i<=n; i++)
+    {
+        g.push_back(static_cast<Scalar>(i)/n);
+    }
+    g.insert(g.end(), m-2*n, 1);
+
+    std::vector<Scalar> b;
+    b.insert(b.end(),2*n,0);
+    for (unsigned int i=1; i<= m-2*n; i++)
+    {
+        b.push_back(static_cast<Scalar>(i)/(m-2*n));
+    }
+    for (unsigned int i=0; i<m; i++)
+    {
+        color_map_vec_[i].setRedChannel(r[i]);
+        color_map_vec_[i].setGreenChannel(g[i]);
+        color_map_vec_[i].setBlueChannel(b[i]);
+    }
+}
+
+template <typename Scalar>
+void ColorMap<Scalar>::coolColorMap()
+{
+    unsigned int m = color_map_vec_.size();
+    unsigned int n = max<unsigned int>(m-1,1);
+    std::vector<Scalar> r;
+    for (unsigned int i=0; i<= m-1; i++)
+    {
+        r.push_back(static_cast<Scalar>(i)/n);
+    }
+    for (unsigned int i=0; i<m; i++)
+    {
+        color_map_vec_[i].setRedChannel(r[i]);
+        color_map_vec_[i].setGreenChannel(1-r[i]);
+        color_map_vec_[i].setBlueChannel(1.0);
+    }
+}
+
+//explicit instantiations
+template class ColorMap<float>;
+template class ColorMap<double>;
+
+} // end of namespace Physika

--- a/Physika_Src/Physika_Render/ColorBar/ColorMap/color_map.h
+++ b/Physika_Src/Physika_Render/ColorBar/ColorMap/color_map.h
@@ -1,0 +1,110 @@
+/*
+ * @file color_map.h 
+ * @Brief a color map class for OpenGL.
+ * @author Wei Chen
+ * 
+ * This file is part of Physika, a versatile physics simulation library.
+ * Copyright (C) 2013 Physika Group.
+ *
+ * This Source Code Form is subject to the terms of the GNU General Public License v2.0. 
+ * If a copy of the GPL was not distributed with this file, you can obtain one at:
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+#ifndef PHYSIKA_RENDER_COLORBAR_COLORMAP_COLOR_MAP_H_
+#define PHYSIKA_RENDER_COLORBAR_COLORMAP_COLOR_MAP_H_
+
+#include <vector>
+#include <iostream>
+#include "Physika_Render/Color/color.h"
+
+namespace Physika{
+
+// Type of ColorMap
+enum ColorMapType
+{
+    Gray,
+    Red,
+    Green,
+    Blue,
+    Jet,
+    Spring,
+    Summer,
+    Autumn,
+    Winter,
+    Hot,
+    Cool
+};
+
+template <typename Scalar>
+class ColorMap
+{
+public:
+    ColorMap();  //default size: 64, default Type: Jet
+    ColorMap(ColorMapType color_map_type, unsigned int color_size);
+    ~ColorMap();
+
+    //getter
+    ColorMapType colorMapType() const;
+    unsigned int colorMapSize() const;
+    const std::vector<Color<Scalar> > & colorMapVec() const;
+
+    // get color via ratio ranging from 0.0 to 1.0, ratio of small than 0.0 or greater than 1.0 is clamped.  
+    const Color<Scalar> & colorViaRatio(Scalar ratio) const;
+    // get color via index, index greater than size of colormap is clamped.
+    const Color<Scalar> & colorViaIndex(unsigned int index) const;
+
+    //setter
+    void setColorMapType(ColorMapType color_map_type);
+    void setColorMapSize(unsigned int color_size);
+    void setColorMapTypeAndSize(ColorMapType color_map_type, unsigned int color_size);
+
+protected:
+    void grayColorMap();
+    void redColorMap();
+    void greenColorMap();
+    void blueColorMap();
+    void jetColorMap();
+    void springColorMap();
+    void summerColorMap();
+    void autumnColorMap();
+    void winterColorMap();
+    void hotColorMap();
+    void coolColorMap();
+
+protected:
+    std::vector<Color<Scalar> > color_map_vec_;
+    ColorMapType color_map_type_;
+};
+
+template <typename Scalar>
+std::ostream & operator << (std::ostream & out, const ColorMap<Scalar> & color_map)
+{
+    out<<"color map: \n";
+    out<<"color map type: ";
+    switch(color_map.colorMapType())
+    {
+    case ColorMapType::Gray:   {out<<"Gray \n"; break;}
+    case ColorMapType::Red:    {out<<"Red \n"; break;}
+    case ColorMapType::Green:  {out<<"Green \n"; break;}
+    case ColorMapType::Blue:   {out<<"Blue \n"; break;}
+    case ColorMapType::Jet:    {out<<"Jet \n"; break;}
+    case ColorMapType::Spring: {out<<"Spring \n"; break;}
+    case ColorMapType::Summer: {out<<"Summer \n"; break;}
+    case ColorMapType::Autumn: {out<<"Autumn \n"; break;}
+    case ColorMapType::Winter: {out<<"Winter \n"; break;}
+    case ColorMapType::Hot:    {out<<"Hot \n"; break;}
+    case ColorMapType::Cool:   {out<<"Cool \n"; break;}
+    }
+    out<<"color map size: "<<color_map.colorMapSize()<<std::endl;
+    for (unsigned int i=0; i<color_map.colorMapSize(); i++)
+    {
+        out<<color_map.colorViaIndex(i)<<std::endl;
+    }
+    return out;
+}
+
+}  //end of namespace Physika
+
+#endif  //PHYSIKA_RENDER_COLORBAR_COLORMAP_COLOR_MAP_H

--- a/Physika_Src/Physika_Render/ColorBar/color_bar.cpp
+++ b/Physika_Src/Physika_Render/ColorBar/color_bar.cpp
@@ -1,0 +1,122 @@
+/*
+ * @file color_bar.cpp
+ * @Brief a color bar class for OpenGL.
+ * @author Wei Chen
+ * 
+ * This file is part of Physika, a versatile physics simulation library.
+ * Copyright (C) 2013 Physika Group.
+ *
+ * This Source Code Form is subject to the terms of the GNU General Public License v2.0. 
+ * If a copy of the GPL was not distributed with this file, you can obtain one at:
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+#include "Physika_Render/ColorBar/color_bar.h"
+
+namespace Physika{
+
+template <typename Scalar>
+ColorBar<Scalar>::ColorBar()
+    :x_len_(3.0),y_len_(30.0),z_len_(2.0),start_point_(0)
+{
+
+}
+
+template <typename Scalar>
+ColorBar<Scalar>::~ColorBar()
+{
+
+}
+
+template <typename Scalar>
+const Vector<Scalar, 3> & ColorBar<Scalar>::startPoint() const
+{
+    return this->start_point_;
+}
+
+template <typename Scalar>
+Scalar ColorBar<Scalar>::xLength() const
+{
+    return this->x_len_;
+}
+
+template <typename Scalar>
+Scalar ColorBar<Scalar>::yLength() const
+{
+    return this->y_len_;
+}
+
+template <typename Scalar>
+Scalar ColorBar<Scalar>::zLength() const
+{
+    return this->z_len_;
+}
+
+template <typename Scalar>
+const ColorMap<Scalar> & ColorBar<Scalar>::colorMap() const
+{
+    return this->color_map_;
+}
+
+template <typename Scalar>
+void ColorBar<Scalar>::setColorMap(const ColorMap<Scalar> & color_map)
+{
+    this->color_map_ = color_map_;
+}
+
+template <typename Scalar>
+void ColorBar<Scalar>::setColorMapSize(unsigned int color_size)
+{
+    this->color_map_.setColorMapSize(color_size);
+}
+
+template <typename Scalar>
+void ColorBar<Scalar>::setColorMapType(ColorMapType color_map_type)
+{
+    this->color_map_.setColorMapType(color_map_type);
+}
+
+template <typename Scalar>
+void ColorBar<Scalar>::setColorMapTypeAndSize(ColorMapType color_map_type, unsigned int color_size)
+{
+    this->color_map_.setColorMapTypeAndSize(color_map_type, color_size);
+}
+
+template <typename Scalar>
+void ColorBar<Scalar>::setStartPoint(const Vector<Scalar, 3> & start_point)
+{
+    this->start_point_ = start_point;
+}
+
+template <typename Scalar>
+void ColorBar<Scalar>::setXLength(Scalar x_len)
+{
+    this->x_len_ = x_len;
+}
+
+template <typename Scalar>
+void ColorBar<Scalar>::setYLength(Scalar y_len)
+{
+    this->y_len_ = y_len;
+}
+
+template <typename Scalar>
+void ColorBar<Scalar>::setZLength(Scalar z_len)
+{
+    this->z_len_ = z_len;
+}
+
+template <typename Scalar>
+void ColorBar<Scalar>::setLength(Scalar x_len, Scalar y_len, Scalar z_len)
+{
+    this->x_len_ = x_len;
+    this->y_len_ = y_len;
+    this->z_len_ = z_len;
+}
+
+//explicit instantiations
+template class ColorBar<float>;
+template class ColorBar<double>;
+
+}

--- a/Physika_Src/Physika_Render/ColorBar/color_bar.cpp
+++ b/Physika_Src/Physika_Render/ColorBar/color_bar.cpp
@@ -18,7 +18,7 @@ namespace Physika{
 
 template <typename Scalar>
 ColorBar<Scalar>::ColorBar()
-    :x_len_(3.0),y_len_(30.0),z_len_(2.0),start_point_(0)
+    :width_(20),height_(300),start_point_(10,70),enable_horizon_(false)
 {
 
 }
@@ -30,27 +30,21 @@ ColorBar<Scalar>::~ColorBar()
 }
 
 template <typename Scalar>
-const Vector<Scalar, 3> & ColorBar<Scalar>::startPoint() const
+const Vector<Scalar, 2> & ColorBar<Scalar>::startPoint() const
 {
     return this->start_point_;
 }
 
 template <typename Scalar>
-Scalar ColorBar<Scalar>::xLength() const
+unsigned int ColorBar<Scalar>::width() const
 {
-    return this->x_len_;
+    return this->width_;
 }
 
 template <typename Scalar>
-Scalar ColorBar<Scalar>::yLength() const
+unsigned int ColorBar<Scalar>::height() const
 {
-    return this->y_len_;
-}
-
-template <typename Scalar>
-Scalar ColorBar<Scalar>::zLength() const
-{
-    return this->z_len_;
+    return this->height_;
 }
 
 template <typename Scalar>
@@ -84,35 +78,46 @@ void ColorBar<Scalar>::setColorMapTypeAndSize(ColorMapType color_map_type, unsig
 }
 
 template <typename Scalar>
-void ColorBar<Scalar>::setStartPoint(const Vector<Scalar, 3> & start_point)
+void ColorBar<Scalar>::setStartPoint(const Vector<Scalar, 2> & start_point)
 {
     this->start_point_ = start_point;
 }
 
 template <typename Scalar>
-void ColorBar<Scalar>::setXLength(Scalar x_len)
+void ColorBar<Scalar>::setWidth(unsigned int width)
 {
-    this->x_len_ = x_len;
+    this->width_ = width;
 }
 
 template <typename Scalar>
-void ColorBar<Scalar>::setYLength(Scalar y_len)
+void ColorBar<Scalar>::setHeight(unsigned int height)
 {
-    this->y_len_ = y_len;
+    this->height_ = height;
 }
 
 template <typename Scalar>
-void ColorBar<Scalar>::setZLength(Scalar z_len)
+void ColorBar<Scalar>::setWidthAndHeight(unsigned int width, unsigned int height)
 {
-    this->z_len_ = z_len;
+    this->width_ = width;
+    this->height_ = height;
 }
 
 template <typename Scalar>
-void ColorBar<Scalar>::setLength(Scalar x_len, Scalar y_len, Scalar z_len)
+void ColorBar<Scalar>::enableHorizon()
 {
-    this->x_len_ = x_len;
-    this->y_len_ = y_len;
-    this->z_len_ = z_len;
+    this->enable_horizon_ = true;
+}
+
+template <typename Scalar>
+void ColorBar<Scalar>::disableHorizon()
+{
+    this->enable_horizon_ = false;
+}
+
+template <typename Scalar>
+bool ColorBar<Scalar>::isHorizon() const
+{
+    return this->enable_horizon_;
 }
 
 //explicit instantiations

--- a/Physika_Src/Physika_Render/ColorBar/color_bar.h
+++ b/Physika_Src/Physika_Render/ColorBar/color_bar.h
@@ -1,0 +1,59 @@
+/*
+ * @file color_bar.h 
+ * @Brief a color bar class for OpenGL.
+ * @author Wei Chen
+ * 
+ * This file is part of Physika, a versatile physics simulation library.
+ * Copyright (C) 2013 Physika Group.
+ *
+ * This Source Code Form is subject to the terms of the GNU General Public License v2.0. 
+ * If a copy of the GPL was not distributed with this file, you can obtain one at:
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+#ifndef PHYSIKA_RENDER_COLORBAR_COLOR_BAR_H_
+#define PHYSIKA_RENDER_COLORBAR_COLOR_BAR_H_
+
+#include "Physika_Render/ColorBar/ColorMap/color_map.h"
+#include "Physika_Core/Vectors/vector_3d.h"
+
+namespace Physika{
+
+template <typename Scalar>
+class ColorBar
+{
+public:
+    ColorBar();
+    ~ColorBar();
+
+    //getter
+    const Vector<Scalar, 3> & startPoint() const;
+    Scalar xLength() const;
+    Scalar yLength() const;
+    Scalar zLength() const;
+    const ColorMap<Scalar> & colorMap() const;
+
+    //setter
+    void setColorMap(const ColorMap<Scalar> & color_map);
+    void setColorMapSize(unsigned int color_size);
+    void setColorMapType(ColorMapType color_map_type);
+    void setColorMapTypeAndSize(ColorMapType color_map_type, unsigned int color_size);
+    void setStartPoint(const Vector<Scalar, 3> & start_point);
+    void setXLength(Scalar x_len);
+    void setYLength(Scalar y_len);
+    void setZLength(Scalar z_len);
+    void setLength(Scalar x_len, Scalar y_len, Scalar z_len);
+
+protected:
+    ColorMap<Scalar> color_map_;
+    Vector<Scalar,3> start_point_; // left bottom corner
+    Scalar x_len_;
+    Scalar y_len_;
+    Scalar z_len_;
+};
+
+
+} // end of namespace Physika
+
+#endif //PHYSIKA_RENDER_COLORBAR_COLOR_BAR_H

--- a/Physika_Src/Physika_Render/ColorBar/color_bar.h
+++ b/Physika_Src/Physika_Render/ColorBar/color_bar.h
@@ -16,7 +16,7 @@
 #define PHYSIKA_RENDER_COLORBAR_COLOR_BAR_H_
 
 #include "Physika_Render/ColorBar/ColorMap/color_map.h"
-#include "Physika_Core/Vectors/vector_3d.h"
+#include "Physika_Core/Vectors/vector_2d.h"
 
 namespace Physika{
 
@@ -28,10 +28,9 @@ public:
     ~ColorBar();
 
     //getter
-    const Vector<Scalar, 3> & startPoint() const;
-    Scalar xLength() const;
-    Scalar yLength() const;
-    Scalar zLength() const;
+    const Vector<Scalar, 2> & startPoint() const;
+    unsigned int width() const;
+    unsigned int height() const;
     const ColorMap<Scalar> & colorMap() const;
 
     //setter
@@ -39,18 +38,22 @@ public:
     void setColorMapSize(unsigned int color_size);
     void setColorMapType(ColorMapType color_map_type);
     void setColorMapTypeAndSize(ColorMapType color_map_type, unsigned int color_size);
-    void setStartPoint(const Vector<Scalar, 3> & start_point);
-    void setXLength(Scalar x_len);
-    void setYLength(Scalar y_len);
-    void setZLength(Scalar z_len);
-    void setLength(Scalar x_len, Scalar y_len, Scalar z_len);
+    void setStartPoint(const Vector<Scalar, 2> & start_point);
+    void setWidth(unsigned int width); // in the unit of pixels
+    void setHeight(unsigned int height); // in the unit of pixels
+    void setWidthAndHeight(unsigned int width, unsigned int height);
+
+    void enableHorizon();  //put the colorbar horizontally
+    void disableHorizon();
+    bool isHorizon() const;
+
 
 protected:
     ColorMap<Scalar> color_map_;
-    Vector<Scalar,3> start_point_; // left bottom corner
-    Scalar x_len_;
-    Scalar y_len_;
-    Scalar z_len_;
+    Vector<Scalar,2> start_point_; // left bottom corner
+    unsigned int width_;  // in the unit of pixels
+    unsigned int height_; // in the unit of pixels
+    bool enable_horizon_;  //whether to put the colorbar horizontally, default: false
 };
 
 

--- a/Physika_Src/Physika_Render/ColorBar_Render/color_bar_render.cpp
+++ b/Physika_Src/Physika_Render/ColorBar_Render/color_bar_render.cpp
@@ -1,0 +1,145 @@
+/*
+ * @file color_bar_render.cpp 
+ * @Brief render of color bar.
+ * @author Wei Chen
+ * 
+ * This file is part of Physika, a versatile physics simulation library.
+ * Copyright (C) 2013 Physika Group.
+ *
+ * This Source Code Form is subject to the terms of the GNU General Public License v2.0. 
+ * If a copy of the GPL was not distributed with this file, you can obtain one at:
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+#include "Physika_Render/OpenGL_Primitives/opengl_primitives.h"
+# include "Physika_Render/ColorBar_Render/color_bar_render.h"
+
+namespace Physika{
+
+template <typename Scalar>
+ColorBarRender<Scalar>::ColorBarRender()
+    :color_bar_(NULL)
+{
+
+}
+
+template <typename Scalar>
+ColorBarRender<Scalar>::ColorBarRender(ColorBar<Scalar> * color_bar)
+    :color_bar_(color_bar)
+{
+
+}
+
+template <typename Scalar>
+ColorBarRender<Scalar>::~ColorBarRender()
+{
+
+}
+
+template <typename Scalar>
+const ColorBar<Scalar> * ColorBarRender<Scalar>::colorBar() const
+{
+    return this->color_bar_;
+}
+
+template <typename Scalar>
+void ColorBarRender<Scalar>::setColorBar(ColorBar<Scalar> * color_bar)
+{
+    if (color_bar == NULL)
+    {
+        std::cerr<<"can't set NULL color bar!\n";
+        std::exit(EXIT_FAILURE);
+    }
+    this->color_bar_ = color_bar;
+}
+
+template <typename Scalar>
+void ColorBarRender<Scalar>::render()
+{
+    glPushAttrib(GL_LIGHTING_BIT|GL_POLYGON_BIT|GL_ENABLE_BIT|GL_TEXTURE_BIT);
+    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL); // set polygon mode FILL for SOLID MODE
+    glDisable(GL_LIGHTING);                    // disable lighting to display the color
+
+    glPushMatrix();
+    const ColorMap<Scalar> & color_map = this->color_bar_->colorMap();
+    unsigned int color_map_size = color_map.colorMapSize();
+
+    Scalar dx = this->color_bar_->xLength();
+    Scalar dy = this->color_bar_->yLength()/color_map_size;
+    Scalar dz = -this->color_bar_->zLength();
+
+    for (unsigned int i=0 ; i<color_map_size; i++)
+    {
+        Vector<Scalar, 3> start_pos = this->color_bar_->startPoint();
+        start_pos[1] += i*dy;
+        Color<Scalar> color = color_map.colorViaIndex(i);
+        this->drawBox(start_pos, dx, dy, dz, color);
+    }
+
+    glPopMatrix();
+    glPopAttrib();
+}
+
+template <typename Scalar>
+void ColorBarRender<Scalar>::drawBox(const Vector<Scalar, 3> & start_pos, Scalar dx, Scalar dy, Scalar dz, const Color<Scalar> & color)
+{
+    Vector<Scalar,3> position_0 = start_pos;
+    Vector<Scalar,3> position_1 = start_pos+Vector<Scalar,3>(dx,0, 0);
+    Vector<Scalar,3> position_2 = start_pos+Vector<Scalar,3>(dx,0, dz);
+    Vector<Scalar,3> position_3 = start_pos+Vector<Scalar,3>(0, 0, dz);
+    Vector<Scalar,3> position_4 = start_pos+Vector<Scalar,3>(0, dy, 0);
+    Vector<Scalar,3> position_5 = start_pos+Vector<Scalar,3>(dx,dy,0);
+    Vector<Scalar,3> position_6 = start_pos+Vector<Scalar,3>(dx,dy,dz);
+    Vector<Scalar,3> position_7 = start_pos+Vector<Scalar,3>(0 ,dy,dz);
+
+    openGLColor3(color);
+
+    glBegin(GL_POLYGON);
+    openGLVertex(position_0);
+    openGLVertex(position_3);
+    openGLVertex(position_2);
+    openGLVertex(position_1);
+    glEnd();
+
+    glBegin(GL_POLYGON);
+    openGLVertex(position_4);
+    openGLVertex(position_5);
+    openGLVertex(position_6);
+    openGLVertex(position_7);
+    glEnd();
+
+    glBegin(GL_POLYGON);
+    openGLVertex(position_0);
+    openGLVertex(position_1);
+    openGLVertex(position_5);
+    openGLVertex(position_4);
+    glEnd();
+
+    glBegin(GL_POLYGON);
+    openGLVertex(position_3);
+    openGLVertex(position_7);
+    openGLVertex(position_6);
+    openGLVertex(position_2);
+    glEnd();
+
+    glBegin(GL_POLYGON);
+    openGLVertex(position_4);
+    openGLVertex(position_7);
+    openGLVertex(position_3);
+    openGLVertex(position_0);
+    glEnd();
+
+    glBegin(GL_POLYGON);
+    openGLVertex(position_1);
+    openGLVertex(position_2);
+    openGLVertex(position_6);
+    openGLVertex(position_5);
+    glEnd();
+}
+
+//explicit instantiation
+template class ColorBarRender<float>;
+template class ColorBarRender<double>;
+
+}// end of namespace Physika

--- a/Physika_Src/Physika_Render/ColorBar_Render/color_bar_render.h
+++ b/Physika_Src/Physika_Render/ColorBar_Render/color_bar_render.h
@@ -1,0 +1,46 @@
+/*
+ * @file color_bar_render.h 
+ * @Brief render of color bar.
+ * @author Wei Chen
+ * 
+ * This file is part of Physika, a versatile physics simulation library.
+ * Copyright (C) 2013 Physika Group.
+ *
+ * This Source Code Form is subject to the terms of the GNU General Public License v2.0. 
+ * If a copy of the GPL was not distributed with this file, you can obtain one at:
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+#ifndef PHYSIKA_RENDER_COLORBAR_RENDER_COLOR_BAR_RENDER_H_
+#define PHYSIKA_RENDER_COLORBAR_RENDER_COLOR_BAR_RENDER_H_
+
+#include "Physika_Render/Render_Base/render_base.h"
+#include "Physika_Render/ColorBar/color_bar.h"
+
+namespace Physika
+{
+
+template <typename Scalar>
+class ColorBarRender: public RenderBase
+{
+public:
+    ColorBarRender();
+    ColorBarRender(ColorBar<Scalar> * color_bar);
+    ~ColorBarRender();
+
+    const ColorBar<Scalar> * colorBar() const;
+    void setColorBar(ColorBar<Scalar> * color_bar);
+    void render();
+
+protected:
+
+    void drawBox(const Vector<Scalar, 3> & start_pos, Scalar dx, Scalar dy, Scalar dz, const Color<Scalar> & color);
+
+protected:
+    ColorBar<Scalar> * color_bar_;
+};
+
+} // end of namespace Physika
+
+#endif // PHYSIKA_RENDER_COLORBAR_RENDER_COLOR_BAR_RENDER_H_

--- a/Projects/TESTS/colorbar_module_test.cpp
+++ b/Projects/TESTS/colorbar_module_test.cpp
@@ -1,0 +1,204 @@
+/*
+ * @file colorbar_module_test.cpp 
+ * @brief Test color bar of Physika.
+ * @author WeiChen
+ * 
+ * This file is part of Physika, a versatile physics simulation library.
+ * Copyright (C) 2013 Physika Group.
+ *
+ * This Source Code Form is subject to the terms of the GNU General Public License v2.0. 
+ * If a copy of the GPL was not distributed with this file, you can obtain one at:
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ */
+
+#include <iostream>
+#include <GL/freeglut.h>
+#include <GL/glui.h>
+#include "Physika_Core/Vectors/vector_3d.h"
+#include "Physika_Core/Utilities/physika_assert.h"
+#include "Physika_Render/OpenGL_Primitives/opengl_primitives.h"
+#include "Physika_GUI/Glut_Window/glut_window.h"
+#include "Physika_Render/ColorBar_Render/color_bar_render.h"
+
+using namespace std;
+using namespace Physika;
+
+ColorMap<double> gray_colormap;
+ColorMap<double> red_colormap;
+ColorMap<double> green_colormap;
+ColorMap<double> blue_colormap;
+ColorMap<double> jet_colormap;
+ColorMap<double> spring_colormap;
+ColorMap<double> summer_colormap;
+ColorMap<double> autumn_colormap;
+ColorMap<double> winter_colormap;
+ColorMap<double> hot_colormap;
+ColorMap<double> cool_colormap;
+
+ColorBar<double> gray_color_bar;
+ColorBar<double> red_color_bar;
+ColorBar<double> green_color_bar;
+ColorBar<double> blue_color_bar;
+ColorBar<double> jet_color_bar;
+ColorBar<double> spring_color_bar;
+ColorBar<double> summer_color_bar;
+ColorBar<double> autumn_color_bar;
+ColorBar<double> winter_color_bar;
+ColorBar<double> hot_color_bar;
+ColorBar<double> cool_color_bar;
+
+ColorBarRender<double> gray_colorbar_render;
+ColorBarRender<double> red_colorbar_render;
+ColorBarRender<double> blue_colorbar_render;
+ColorBarRender<double> green_colorbar_render;
+ColorBarRender<double> jet_colorbar_render;
+ColorBarRender<double> spring_colorbar_render;
+ColorBarRender<double> summer_colorbar_render;
+ColorBarRender<double> autumn_colorbar_render;
+ColorBarRender<double> winter_colorbar_render;
+ColorBarRender<double> hot_colorbar_render;
+ColorBarRender<double> cool_colorbar_render;
+
+
+void displayFunction()
+{
+
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);		     // Clear Screen and Depth Buffer
+    GlutWindow *cur_window = (GlutWindow*)glutGetWindowData();
+    //cur_window->orbitCameraRight(0.1);
+	
+    //(cur_window->camera()).look();
+	//cur_window->lightAtIndex(0)->setPosition(Vector<float,3>(0,50,0));
+	cur_window->applyCameraAndLights();
+
+    gray_colorbar_render.render();
+    red_colorbar_render.render();
+    green_colorbar_render.render();
+    blue_colorbar_render.render();
+    jet_colorbar_render.render();
+    spring_colorbar_render.render();
+    summer_colorbar_render.render();
+    autumn_colorbar_render.render();
+    winter_colorbar_render.render();
+    hot_colorbar_render.render();
+    cool_colorbar_render.render();
+
+    cur_window->displayFrameRate();
+    glutSwapBuffers();
+}
+
+void idleFunction()
+{
+    cout<<"Custom idle function\n";
+}
+
+void initFunction()
+{
+    gray_colormap.setColorMapTypeAndSize(ColorMapType::Gray, 16);
+    red_colormap.setColorMapTypeAndSize(ColorMapType::Red, 16);
+    green_colormap.setColorMapTypeAndSize(ColorMapType::Green, 16);
+    blue_colormap.setColorMapTypeAndSize(ColorMapType::Blue, 16);
+    jet_colormap.setColorMapTypeAndSize(ColorMapType::Jet, 16);
+    spring_colormap.setColorMapTypeAndSize(ColorMapType::Spring, 16);
+    summer_colormap.setColorMapTypeAndSize(ColorMapType::Summer, 16);
+    autumn_colormap.setColorMapTypeAndSize(ColorMapType::Autumn, 16);
+    winter_colormap.setColorMapTypeAndSize(ColorMapType::Winter, 16);
+    hot_colormap.setColorMapTypeAndSize(ColorMapType::Hot, 16);
+    cool_colormap.setColorMapTypeAndSize(ColorMapType::Cool, 16);
+
+    cout<<jet_colormap<<endl;
+
+    gray_color_bar.setColorMapTypeAndSize(ColorMapType::Gray, 256);
+    gray_color_bar.setStartPoint(Vector<double,2>(10,70));
+    gray_colorbar_render.setColorBar(&gray_color_bar);
+
+    red_color_bar.setColorMapTypeAndSize(ColorMapType::Red, 256);
+    red_color_bar.setStartPoint(Vector<double,2>(40,70));
+    red_colorbar_render.setColorBar(&red_color_bar);
+
+    green_color_bar.setColorMapTypeAndSize(ColorMapType::Green, 256);
+    green_color_bar.setStartPoint(Vector<double,2>(70,70));
+    green_colorbar_render.setColorBar(&green_color_bar);
+
+    blue_color_bar.setColorMapTypeAndSize(ColorMapType::Blue, 256);
+    blue_color_bar.setStartPoint(Vector<double,2>(100,70));
+    blue_colorbar_render.setColorBar(&blue_color_bar);
+
+    jet_color_bar.setColorMapTypeAndSize(ColorMapType::Jet, 256);
+    jet_color_bar.setStartPoint(Vector<double,2>(130,70));
+    jet_colorbar_render.setColorBar(&jet_color_bar);
+
+    spring_color_bar.setColorMapTypeAndSize(ColorMapType::Spring, 256);
+    spring_color_bar.setStartPoint(Vector<double,2>(160,70));
+    spring_colorbar_render.setColorBar(&spring_color_bar);
+
+    summer_color_bar.setColorMapTypeAndSize(ColorMapType::Summer, 256);
+    summer_color_bar.setStartPoint(Vector<double,2>(190,70));
+    summer_colorbar_render.setColorBar(&summer_color_bar);
+
+    autumn_color_bar.setColorMapTypeAndSize(ColorMapType::Autumn, 256);
+    autumn_color_bar.setStartPoint(Vector<double,2>(220,70));
+    autumn_colorbar_render.setColorBar(&autumn_color_bar);
+
+    winter_color_bar.setColorMapTypeAndSize(ColorMapType::Winter, 256);
+    winter_color_bar.setStartPoint(Vector<double,2>(250,70));
+    winter_colorbar_render.setColorBar(&winter_color_bar);
+
+    hot_color_bar.setColorMapTypeAndSize(ColorMapType::Hot, 256);
+    hot_color_bar.setStartPoint(Vector<double,2>(280,70));
+    hot_colorbar_render.setColorBar(&hot_color_bar);
+
+    cool_color_bar.setColorMapTypeAndSize(ColorMapType::Cool, 256);
+    cool_color_bar.setStartPoint(Vector<double,2>(310,70));
+    cool_color_bar.enableHorizon();
+    cool_colorbar_render.setColorBar(&cool_color_bar);
+
+	/***********************************************************************/
+	// note: we have to set our light in initFunction, otherwise the setting will not be vaild.
+
+	GlutWindow *cur_window = (GlutWindow*)glutGetWindowData();
+	cur_window->lightAtIndex(0)->setPosition(Vector<float,3>(0,50,0));
+	cur_window->lightAtIndex(0)->turnOn();
+
+    glClearDepth(1.0);
+    glHint(GL_LINE_SMOOTH_HINT, GL_NICEST);	
+	glHint(GL_POLYGON_SMOOTH_HINT, GL_NICEST);	
+	glClearColor( 0.0, 0.0, 0.0, 1.0 );
+
+	glShadeModel( GL_SMOOTH );
+    glEnable(GL_DEPTH_TEST);
+    glEnable(GL_LIGHTING);
+}
+
+void keyboardFunction(unsigned char key, int x, int y )
+{
+    GlutWindow::bindDefaultKeys(key,x,y);
+    switch(key)
+    {
+    case 't':
+        cout<<"test\n";
+        break;
+    default:
+        break;
+    }
+}
+
+int main()
+{
+    GlutWindow glut_window;
+    cout<<"Window name: "<<glut_window.name()<<"\n";
+    cout<<"Window size: "<<glut_window.width()<<"x"<<glut_window.height()<<"\n";
+    glut_window.setCameraPosition(Vector<double,3>(0,0,200));
+    glut_window.setCameraFocusPosition(Vector<double,3>(0,0,0));
+    glut_window.setCameraNearClip(0.1);
+    glut_window.setCameraFarClip(1.0e4);
+    glut_window.setDisplayFunction(displayFunction);
+    //glut_window.setIdleFunction(idleFunction);
+    glut_window.setInitFunction(initFunction);
+    cout<<"Test GlutWindow with custom display function:\n";
+    glut_window.createWindow();
+    cout<<"Window size: "<<glut_window.width()<<"x"<<glut_window.height()<<"\n";
+    cout<<"Test window with GLUI controls:\n";
+    return 0;
+}


### PR DESCRIPTION
colorbar module is implemented, which includes three classes: ColorMap, ColorBar, and ColorBarRender.  
The ColorMap class consists of 11 different types of colormap frequently used: Gray, Red, Green, Blue, Jet,Hot, Cool, Spring, Summer, Autumn, Winter. The way to generate these colormaps is obtained from MATLAB source codes, and I have test each colormap by comparing the result with Matlab.
 The following picture displays these different colorbars:
![_ ydcs 630gz8i cer uze](https://cloud.githubusercontent.com/assets/5646651/6978081/ae9467ba-d9fd-11e4-9f55-e6ff3125b224.jpg)
